### PR TITLE
Allow configurable non-safe HTTP methods and body sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ amac report  --run-dir out/run_YYYY-MM-DD_HH-MM-SS
 
 ### `scope.yml` (advanced example)
 
+Disable `safe_methods_only` and list `non_safe_methods` to probe operations like
+`POST` or `PUT`.
+
 ```yaml
 allowed:
   - api.example.com
@@ -155,6 +158,7 @@ path_policy:
 
 request_policy:
   safe_methods_only: true
+  non_safe_methods: []  # e.g., [POST, PUT]
   max_rps: 2
   concurrency: 6
   per_host_concurrency: 2

--- a/amac/models.py
+++ b/amac/models.py
@@ -11,6 +11,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when pydantic missing
     _USE_PYDANTIC = False
 
 PrivacyLevel = Literal["none", "minimal", "strict"]
+HttpMethod = Literal["GET", "HEAD", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
 
 if _USE_PYDANTIC:
     # ------------------------------------------------------------------
@@ -26,6 +27,10 @@ if _USE_PYDANTIC:
         safe_methods_only: bool = Field(
             default=True,
             description="If true, only emit safe HTTP methods (GET/HEAD) in MVP.",
+        )
+        non_safe_methods: List[HttpMethod] = Field(
+            default_factory=list,
+            description="Additional HTTP methods to allow when safe_methods_only is false.",
         )
         max_rps: int = Field(default=2, ge=1, description="Maximum requests per second across all hosts.")
         concurrency: int = Field(default=4, ge=1, description="Maximum in-flight requests (global).")
@@ -158,8 +163,6 @@ if _USE_PYDANTIC:
     class AuthConfig(BaseModel):
         auth_schemes: List[AuthScheme] = Field(default_factory=list)
 
-    HttpMethod = Literal["GET", "HEAD"]
-
     class Endpoint(BaseModel):
         method: HttpMethod
         url: str
@@ -195,6 +198,7 @@ else:
     @dataclass
     class RequestPolicy:
         safe_methods_only: bool = True
+        non_safe_methods: List[str] = field(default_factory=list)
         max_rps: int = 2
         concurrency: int = 4
         per_host_concurrency: int = 2
@@ -247,8 +251,6 @@ else:
     @dataclass
     class AuthConfig:
         auth_schemes: List[AuthScheme] = field(default_factory=list)
-
-    HttpMethod = Literal["GET", "HEAD"]
 
     @dataclass
     class Endpoint:

--- a/examples/scope.yml
+++ b/examples/scope.yml
@@ -14,6 +14,8 @@ denied:
 request_policy:
   # MVP runs only safe methods (GET/HEAD). Keep true for Day 1–2.
   safe_methods_only: true
+  # List non-safe HTTP methods to probe when safe_methods_only is false.
+  non_safe_methods: []  # e.g., [POST, PUT]
   # Throttle so you don't hammer targets during mapping/checking.
   max_rps: 2
   concurrency: 4

--- a/tests/test_openapi_mapping.py
+++ b/tests/test_openapi_mapping.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+import json
 
 from amac.config import load_scope_config
 from amac.discovery.openapi import load_and_map_openapi
@@ -29,3 +30,46 @@ def test_map_openapi_local():
         ("GET", "http://127.0.0.1:8008/search?q=test&page=1"),
     }
     assert got == expected, f"unexpected endpoints:\nGot: {got}\nExpected: {expected}"
+
+
+def test_map_openapi_post_body(tmp_path):
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Demo", "version": "1.0"},
+        "paths": {
+            "/items": {
+                "post": {
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["name"],
+                                    "properties": {"name": {"type": "string"}},
+                                }
+                            }
+                        },
+                    },
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(spec))
+
+    scope_path = tmp_path / "scope.yml"
+    scope_path.write_text(
+        "allowed:\n  - example.com\nbase_urls:\n  - https://example.com\nrequest_policy:\n  safe_methods_only: false\n  non_safe_methods:\n    - POST\n"
+    )
+
+    scope_cfg = load_scope_config(str(scope_path))
+    es = asyncio.run(load_and_map_openapi(str(spec_path), scope_cfg))
+
+    assert {(e.method, e.url) for e in es.endpoints} == {(
+        "POST",
+        "https://example.com/items",
+    )}
+    body = es.endpoints[0].extra.get("body")
+    assert body == {"name": "alice"}


### PR DESCRIPTION
## Summary
- Allow configuration of additional HTTP methods via `non_safe_methods`
- Parse all HTTP methods in OpenAPI and sample bodies for required request payloads
- Send sampled bodies during probes and record them in request snapshots

## Testing
- `PYTHONPATH=. pytest`

